### PR TITLE
Add build support for armv7 (Android)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,26 @@ jobs:
           path: native/target/aarch64-apple-ios/${{ env._RUST_BUILD_CONFIG }}/libyaha_native.a
           retention-days: 1
 
+  build-android-arm:
+    name: Build Native library (android-arm)
+    if: ${{ !inputs.build-only-linux }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: native
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt update && sudo apt install gcc-multilib
+      - run: rustup target add armv7-linux-android
+      - run: cargo install cargo-ndk
+      - run: cargo ndk -t armeabi-v7a build --profile ${{ env._RUST_BUILD_CONFIG == 'debug' && 'dev' || env._RUST_BUILD_CONFIG }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: android-arm
+          path: native/target/armv7-linux-android/${{ env._RUST_BUILD_CONFIG }}/libyaha_native.so
+          retention-days: 1
+
   build-android-arm64:
     name: Build Native library (android-arm64)
     if: ${{ !inputs.build-only-linux }}
@@ -170,6 +190,7 @@ jobs:
       - build-osx-arm64
       - build-ios-x64
       - build-ios-arm64
+      - build-android-arm
       - build-android-arm64
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,13 +151,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update && sudo apt install gcc-multilib
-      - run: rustup target add armv7-linux-android
+      - run: rustup target add armv7-linux-androideabi
       - run: cargo install cargo-ndk
       - run: cargo ndk -t armeabi-v7a build --profile ${{ env._RUST_BUILD_CONFIG == 'debug' && 'dev' || env._RUST_BUILD_CONFIG }}
       - uses: actions/upload-artifact@v3
         with:
           name: android-arm
-          path: native/target/armv7-linux-android/${{ env._RUST_BUILD_CONFIG }}/libyaha_native.so
+          path: native/target/armv7-linux-androideabi/${{ env._RUST_BUILD_CONFIG }}/libyaha_native.so
           retention-days: 1
 
   build-android-arm64:

--- a/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm.meta
+++ b/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7294985256c8dc44fb397acb8787dfd6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm/native.meta
+++ b/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm/native.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa44319386c7fff40a295500b9044355
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm/native/libCysharp.Net.Http.YetAnotherHttpHandler.Native.so.meta
+++ b/src/YetAnotherHttpHandler/Plugins/Cysharp.Net.Http.YetAnotherHttpHandler.Native/runtimes/android-arm/native/libCysharp.Net.Http.YetAnotherHttpHandler.Native.so.meta
@@ -1,0 +1,80 @@
+fileFormatVersion: 2
+guid: 15a6dda5b8077494ca998a4801791195
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.csproj
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.csproj
@@ -40,6 +40,7 @@
     <YahaNativeArtifactTarget Include="osx-arm64" RustTarget="aarch64-apple-darwin" Prefix="lib" Ext=".dylib" />
     <YahaNativeArtifactTarget Include="ios-x64" RustTarget="x86_64-apple-ios" Prefix="lib" Ext=".a" />
     <YahaNativeArtifactTarget Include="ios-arm64" RustTarget="aarch64-apple-ios" Prefix="lib" Ext=".a" />
+    <YahaNativeArtifactTarget Include="android-arm" RustTarget="armv7-linux-android" Prefix="lib" Ext=".so" />
     <YahaNativeArtifactTarget Include="android-arm64" RustTarget="aarch64-linux-android" Prefix="lib" Ext=".so" />
   </ItemGroup>
 

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.csproj
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.csproj
@@ -40,7 +40,7 @@
     <YahaNativeArtifactTarget Include="osx-arm64" RustTarget="aarch64-apple-darwin" Prefix="lib" Ext=".dylib" />
     <YahaNativeArtifactTarget Include="ios-x64" RustTarget="x86_64-apple-ios" Prefix="lib" Ext=".a" />
     <YahaNativeArtifactTarget Include="ios-arm64" RustTarget="aarch64-apple-ios" Prefix="lib" Ext=".a" />
-    <YahaNativeArtifactTarget Include="android-arm" RustTarget="armv7-linux-android" Prefix="lib" Ext=".so" />
+    <YahaNativeArtifactTarget Include="android-arm" RustTarget="armv7-linux-androideabi" Prefix="lib" Ext=".so" />
     <YahaNativeArtifactTarget Include="android-arm64" RustTarget="aarch64-linux-android" Prefix="lib" Ext=".so" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #4 

This PR enables to build the native library for Android running on armv7.
But, we have yet to verify that the deliverable work.