### PR TITLE
Add support for client auth certificates & keys

### DIFF
--- a/native/yaha_native/src/binding.rs
+++ b/native/yaha_native/src/binding.rs
@@ -71,6 +71,34 @@ pub extern "C" fn yaha_client_config_add_root_certificates(ctx: *mut YahaNativeC
 }
 
 #[no_mangle]
+pub extern "C" fn yaha_client_config_add_client_auth_certificates(ctx: *mut YahaNativeContext, auth_certs: *const StringBuffer) -> usize {
+    let ctx = YahaNativeContextInternal::from_raw_context(ctx);
+    let certs: Vec<rustls::Certificate> = unsafe { rustls_pemfile::certs(&mut (*auth_certs).to_bytes()).unwrap().into_iter().map(rustls::Certificate).collect() };
+
+    let count = certs.len();
+
+    if count > 0 {
+        ctx.client_auth_certificates.get_or_insert(certs);
+    }
+
+    count
+}
+
+#[no_mangle]
+pub extern "C" fn yaha_client_config_add_client_auth_key(ctx: *mut YahaNativeContext, auth_key: *const StringBuffer) -> usize {
+    let ctx = YahaNativeContextInternal::from_raw_context(ctx);
+    let keys: Vec<rustls::PrivateKey> = unsafe { rustls_pemfile::pkcs8_private_keys(&mut (*auth_key).to_bytes()).unwrap().into_iter().map(rustls::PrivateKey).collect() };
+
+    let count = keys.len();
+
+    if count > 0 {
+        ctx.client_auth_key.get_or_insert(keys[0].clone());
+    }
+
+    count
+}
+
+#[no_mangle]
 pub extern "C" fn yaha_client_config_skip_certificate_verification(ctx: *mut YahaNativeContext, val: bool) {
     let ctx = YahaNativeContextInternal::from_raw_context(ctx);
     ctx.skip_certificate_verification = Some(val);

--- a/src/YetAnotherHttpHandler/NativeMethods.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.g.cs
@@ -42,6 +42,12 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_root_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_root_certificates(YahaNativeContext* ctx, StringBuffer* root_certs);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern nuint yaha_client_config_add_client_auth_certificates(YahaNativeContext* ctx, StringBuffer* auth_certs);
+
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_key", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern nuint yaha_client_config_add_client_auth_key(YahaNativeContext* ctx, StringBuffer* auth_key);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_skip_certificate_verification", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_skip_certificate_verification(YahaNativeContext* ctx, [MarshalAs(UnmanagedType.U1)] bool val);
 

--- a/src/YetAnotherHttpHandler/NativeMethodsFuncPtr.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethodsFuncPtr.g.cs
@@ -28,6 +28,12 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_root_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_root_certificates(YahaNativeContext* ctx, StringBuffer* root_certs);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern nuint yaha_client_config_add_client_auth_certificates(YahaNativeContext* ctx, StringBuffer* auth_certs);
+
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_key", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern nuint yaha_client_config_add_client_auth_key(YahaNativeContext* ctx, StringBuffer* auth_key);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_skip_certificate_verification", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_skip_certificate_verification(YahaNativeContext* ctx, [MarshalAs(UnmanagedType.U1)] bool val);
 

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
@@ -51,6 +51,16 @@ namespace Cysharp.Net.Http
         public string? RootCertificates { get => _settings.RootCertificates; set => _settings.RootCertificates = value; }
 
         /// <summary>
+        /// Gets or sets a custom client auth certificates.
+        /// </summary>
+        public string? ClientAuthCertificates { get => _settings.ClientAuthCertificates; set => _settings.ClientAuthCertificates = value; }
+
+        /// <summary>
+        /// Gets or sets a custom client auth key.
+        /// </summary>
+        public string? ClientAuthKey { get => _settings.ClientAuthKey; set => _settings.ClientAuthKey = value; }
+
+        /// <summary>
         /// Gets or sets the SETTINGS_INITIAL_WINDOW_SIZE option for HTTP2 stream-level flow control.
         /// </summary>
         /// <remarks>
@@ -174,6 +184,8 @@ namespace Cysharp.Net.Http
         public bool? Http2Only { get; set; }
         public bool? SkipCertificateVerification { get; set; }
         public string? RootCertificates { get; set; }
+        public string? ClientAuthCertificates { get; set; }
+        public string? ClientAuthKey { get; set; }
         public uint? Http2InitialStreamWindowSize { get; set; }
         public uint? Http2InitialConnectionWindowSize { get; set; }
         public bool? Http2AdaptiveWindow { get; set; }
@@ -193,6 +205,8 @@ namespace Cysharp.Net.Http
                 Http2Only = this.Http2Only,
                 SkipCertificateVerification = this.SkipCertificateVerification,
                 RootCertificates = this.RootCertificates,
+                ClientAuthCertificates = this.ClientAuthCertificates,
+                ClientAuthKey = this.ClientAuthKey,
                 Http2InitialStreamWindowSize = this.Http2InitialStreamWindowSize,
                 Http2InitialConnectionWindowSize = this.Http2InitialConnectionWindowSize,
                 Http2AdaptiveWindow = this.Http2AdaptiveWindow,


### PR DESCRIPTION
With this change, a custom client certificate and key can be provided, allowing the gRPC server to authenticate a client when a specific client SSL certificate and key are required for authentication.