### PR TITLE
Change actions runner OS to ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
   build-linux-x64:
     name: Build Native library (linux-x64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
This PR downgrades OS of the actions runner because the dependent version of glibc depends on the OS on which it is built.