### PR TITLE
Update action.yaml to use Cysharp/Actions/setup-dotnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,7 @@ jobs:
         working-directory: native
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: cargo build --target x86_64-pc-windows-msvc --profile ${{ env._RUST_BUILD_CONFIG == 'debug' && 'dev' || env._RUST_BUILD_CONFIG }}
       - uses: actions/upload-artifact@v3
         with:
@@ -64,9 +62,7 @@ jobs:
         working-directory: native
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: cargo build --target x86_64-unknown-linux-gnu --profile ${{ env._RUST_BUILD_CONFIG == 'debug' && 'dev' || env._RUST_BUILD_CONFIG }}
       - uses: actions/upload-artifact@v3
         with:
@@ -85,9 +81,7 @@ jobs:
         working-directory: native
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: '7.0.x'
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: cargo build --target x86_64-apple-darwin --profile ${{ env._RUST_BUILD_CONFIG == 'debug' && 'dev' || env._RUST_BUILD_CONFIG }}
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## tl;dr;

To central manage setup-dotnet verseion. It support both .NET 6,7 and 8. No need specify version.