### PR TITLE
Problem of status code being StatusCode.Internal in Airplane mode, etc.

### DIFF
--- a/src/YetAnotherHttpHandler/ResponseContext.cs
+++ b/src/YetAnotherHttpHandler/ResponseContext.cs
@@ -155,7 +155,7 @@ namespace Cysharp.Net.Http
             }
             catch (Exception e)
             {
-                throw new HttpRequestException(e.Message);
+                throw new HttpRequestException(e.Message, e);
             }
         }
     }


### PR DESCRIPTION
[Grpc.Net.Client has an implementation that interprets the StatusCode as Unavailable if an exception derived from SocketException/IOException is included as InnerException among HttpRequestExceptions.](https://github.com/grpc/grpc-dotnet/blob/v2.60.0/src/Grpc.Net.Client/Internal/GrpcProtocolHelpers.cs#L510-L513) In the current YetAnotherHttpHandler, InnerException is not set, so when an error occurs in an offline state, the StatusCode becomes Internal, and the behavior is different from when using the genuine HttpHandler.

Changed to pass the exception (IOException) as InnerException to HttpRequestException, which is thrown when an exception occurs when getting results with ResponseContext.GetResponseAsync.