### PR TITLE
Enabling debug logging on Unity

### DIFF
--- a/src/YetAnotherHttpHandler/YahaEventSource.cs
+++ b/src/YetAnotherHttpHandler/YahaEventSource.cs
@@ -9,7 +9,12 @@ namespace Cysharp.Net.Http
 #if UNITY_2021_1_OR_NEWER
     internal class YahaEventSource
     {
-        public bool IsEnabled() => false;
+        public bool IsEnabled()
+#if YAHA_ENABLE_DEBUG_TRACING
+            => true;
+#else
+            => false;
+#endif
 
         public static YahaEventSource Log { get; } = new();
 


### PR DESCRIPTION
To enable debug logging on Unity, set `YAHA_ENABLE_DEBUG_TRACING` to "Scripting Define Symbols".
![image](https://github.com/Cysharp/YetAnotherHttpHandler/assets/9012/3230acd0-11df-4e1a-821d-e9cba03eb474)
