### PR TITLE
Fix http1 not being enabled in tls

### DIFF
--- a/native/yaha_native/src/context.rs
+++ b/native/yaha_native/src/context.rs
@@ -141,7 +141,7 @@ impl YahaNativeContextInternal<'_> {
         let builder = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(tls_config)
             .https_or_http()
-            .enable_http2();
+            .enable_all_versions();
 
         // Almost the same as `builder.build()`, but specify `set_nodelay(true)`.
         let mut http_conn = HttpConnector::new();


### PR DESCRIPTION
The hyper_rustls builder had only HTTP/2 enabled, which caused failures when connecting to HTTPS servers that don't support HTTP/2. 
Changing enable_http2 to enable_all_versions, allowing fallback to earlier HTTP versions and resolving the issue.