### PR TITLE
Support with_server_name option of hyper_rustls::HttpsConnectorBuilder

### DIFF
--- a/native/yaha_native/src/binding.rs
+++ b/native/yaha_native/src/binding.rs
@@ -110,6 +110,16 @@ pub extern "C" fn yaha_client_config_add_root_certificates(
 }
 
 #[no_mangle]
+pub extern "C" fn yaha_client_config_add_override_server_name(
+    ctx: *mut YahaNativeContext,
+    override_server_name: *const StringBuffer,
+) {
+    let ctx = YahaNativeContextInternal::from_raw_context(ctx);
+    let server_name = unsafe { (*override_server_name).to_str() };
+    ctx.override_server_name.get_or_insert(server_name.to_string());
+}
+
+#[no_mangle]
 pub extern "C" fn yaha_client_config_add_client_auth_certificates(
     ctx: *mut YahaNativeContext,
     auth_certs: *const StringBuffer,

--- a/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
+++ b/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
@@ -86,6 +86,16 @@ namespace Cysharp.Net.Http
                     if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"yaha_client_config_add_root_certificates: ValidCertificatesCount={validCertificatesCount}");
                 }
             }
+            if (settings.OverrideServerName is { } overrideServerName)
+            {
+                if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"Option '{nameof(settings.OverrideServerName)}' = {overrideServerName}");
+                var overrideServerNameBytes = Encoding.UTF8.GetBytes(overrideServerName);
+                fixed (byte* buffer = overrideServerNameBytes)
+                {
+                    var sb = new StringBuffer(buffer, overrideServerNameBytes.Length);
+                    NativeMethods.yaha_client_config_add_override_server_name(ctx, &sb);
+                }
+            }
             if (settings.ClientAuthKey is { } clientAuthKey)
             {
                 if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"Option '{nameof(settings.ClientAuthKey)}' = {clientAuthKey}");

--- a/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
@@ -47,6 +47,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_root_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_root_certificates(YahaNativeContext* ctx, StringBuffer* root_certs);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_override_server_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_client_config_add_override_server_name(YahaNativeContext* ctx, StringBuffer* override_server_name);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_client_auth_certificates(YahaNativeContext* ctx, StringBuffer* auth_certs);
 

--- a/src/YetAnotherHttpHandler/NativeMethods.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.g.cs
@@ -52,6 +52,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_root_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_root_certificates(YahaNativeContext* ctx, StringBuffer* root_certs);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_add_override_server_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_client_config_add_override_server_name(YahaNativeContext* ctx, StringBuffer* override_server_name);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_add_client_auth_certificates", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern nuint yaha_client_config_add_client_auth_certificates(YahaNativeContext* ctx, StringBuffer* auth_certs);
 

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
@@ -50,6 +50,11 @@ namespace Cysharp.Net.Http
         public string? RootCertificates { get => _settings.RootCertificates; set => _settings.RootCertificates = value; }
 
         /// <summary>
+        /// Gets or sets a value that specifies subject alternative name (SAN) of the certificate.
+        /// </summary>
+        public string? OverrideServerName { get => _settings.OverrideServerName; set => _settings.OverrideServerName = value; }
+
+        /// <summary>
         /// Gets or sets a custom client auth certificates.
         /// </summary>
         public string? ClientAuthCertificates { get => _settings.ClientAuthCertificates; set => _settings.ClientAuthCertificates = value; }
@@ -192,6 +197,7 @@ namespace Cysharp.Net.Http
         public bool? Http2Only { get; set; }
         public bool? SkipCertificateVerification { get; set; }
         public string? RootCertificates { get; set; }
+        public string? OverrideServerName { get; set; }
         public string? ClientAuthCertificates { get; set; }
         public string? ClientAuthKey { get; set; }
         public uint? Http2InitialStreamWindowSize { get; set; }
@@ -214,6 +220,7 @@ namespace Cysharp.Net.Http
                 Http2Only = this.Http2Only,
                 SkipCertificateVerification = this.SkipCertificateVerification,
                 RootCertificates = this.RootCertificates,
+                OverrideServerName = this.OverrideServerName,
                 ClientAuthCertificates = this.ClientAuthCertificates,
                 ClientAuthKey = this.ClientAuthKey,
                 Http2InitialStreamWindowSize = this.Http2InitialStreamWindowSize,


### PR DESCRIPTION
# Problem
In some situations using self-signed certificate without domain (e.g. connecting to scalable dedicated game servers for PvP matching), the subject alternative name (SAN) of the certificate must be specified for verification.
hyper_rustls provides `with_server_name` option for this purpose:

https://docs.rs/hyper-rustls/latest/hyper_rustls/struct.HttpsConnectorBuilder.html#method.with_server_name
> Override server name for the TLS stack
By default, for each connection hyper-rustls will extract host portion of the destination URL and verify that server certificate contains this value.
If this method is called, hyper-rustls will instead verify that server certificate contains override_server_name. Domain name included in the URL will not affect certificate validation.

but currently YetAnotherHttpHandler does not support this feature.

# Solution
This PR adds a string property `OverrideServerName` to the class `YetAnotherHttpHandler` and propagates it to `hyper_rustls::HttpsConnectorBuilder` 's `with_server_name` method.

# Note
`with_server_name` is deprecated since `hyper-rustls 0.27.1` and we should use `with_server_name_resolver` instead.
This PR still calls `with_server_name` because this project currently uses `hyper-rustls 0.26.0`.
Please replace the implementation when you upgrade the crate.

