### PR TITLE
add TCP connect timeout option

### DIFF
--- a/native/yaha_native/src/binding.rs
+++ b/native/yaha_native/src/binding.rs
@@ -280,6 +280,15 @@ pub extern "C" fn yaha_client_config_http2_keep_alive_while_idle(
 }
 
 #[no_mangle]
+pub extern "C" fn yaha_client_config_connect_timeout(
+    ctx: *mut YahaNativeContext,
+    timeout_milliseconds: u64,
+) {
+    let ctx = YahaNativeContextInternal::from_raw_context(ctx);
+    ctx.connect_timeout.get_or_insert(Duration::from_millis(timeout_milliseconds));
+}
+
+#[no_mangle]
 pub extern "C" fn yaha_client_config_http2_max_concurrent_reset_streams(
     ctx: *mut YahaNativeContext,
     max: usize,

--- a/native/yaha_native/src/context.rs
+++ b/native/yaha_native/src/context.rs
@@ -1,6 +1,7 @@
 use std::{
     num::NonZeroIsize,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 use futures_channel::mpsc::Sender;
 use http_body_util::combinators::BoxBody;
@@ -55,6 +56,7 @@ pub struct YahaNativeContextInternal<'a> {
     pub skip_certificate_verification: Option<bool>,
     pub root_certificates: Option<rustls::RootCertStore>,
     pub override_server_name: Option<String>,
+    pub connect_timeout: Option<Duration>,
     pub client_auth_certificates: Option<Vec<CertificateDer<'a>>>,
     pub client_auth_key: Option<PrivateKeyDer<'a>>,
     pub client: Option<Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, hyper::Error>>>,
@@ -81,6 +83,7 @@ impl YahaNativeContextInternal<'_> {
             skip_certificate_verification: None,
             root_certificates: None,
             override_server_name: None,
+            connect_timeout: None,
             client_auth_certificates: None,
             client_auth_key: None,
             on_status_code_and_headers_receive,
@@ -157,6 +160,7 @@ impl YahaNativeContextInternal<'_> {
         let mut http_conn = HttpConnector::new();
         http_conn.set_nodelay(true);
         http_conn.enforce_http(false);
+        http_conn.set_connect_timeout(self.connect_timeout);
         builder.wrap_connector(http_conn)
     }
 

--- a/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
+++ b/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
@@ -141,6 +141,11 @@ namespace Cysharp.Net.Http
                 if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"Option '{nameof(settings.Http2MaxFrameSize)}' = {http2MaxFrameSize}");
                 NativeMethods.yaha_client_config_http2_max_frame_size(ctx, http2MaxFrameSize);
             }
+            if (settings.ConnectTimeout is { } connectTimeout)
+            {
+                if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"Option '{nameof(settings.ConnectTimeout)}' = {connectTimeout}");
+                NativeMethods.yaha_client_config_connect_timeout(ctx, (ulong)connectTimeout.TotalMilliseconds);
+            }
             if (settings.Http2KeepAliveInterval is { } http2KeepAliveInterval)
             {
                 if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Info($"Option '{nameof(settings.Http2KeepAliveInterval)}' = {http2KeepAliveInterval}");

--- a/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
@@ -89,6 +89,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_http2_keep_alive_while_idle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_http2_keep_alive_while_idle(YahaNativeContext* ctx, [MarshalAs(UnmanagedType.U1)] bool val);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_connect_timeout", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_client_config_connect_timeout(YahaNativeContext* ctx, ulong timeout_milliseconds);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_http2_max_concurrent_reset_streams", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_http2_max_concurrent_reset_streams(YahaNativeContext* ctx, nuint max);
 

--- a/src/YetAnotherHttpHandler/NativeMethods.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.g.cs
@@ -94,6 +94,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_client_config_http2_keep_alive_while_idle", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_http2_keep_alive_while_idle(YahaNativeContext* ctx, [MarshalAs(UnmanagedType.U1)] bool val);
 
+        [DllImport(__DllName, EntryPoint = "yaha_client_config_connect_timeout", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_client_config_connect_timeout(YahaNativeContext* ctx, ulong timeout_milliseconds);
+
         [DllImport(__DllName, EntryPoint = "yaha_client_config_http2_max_concurrent_reset_streams", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void yaha_client_config_http2_max_concurrent_reset_streams(YahaNativeContext* ctx, nuint max);
 

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
@@ -95,6 +95,16 @@ namespace Cysharp.Net.Http
         /// <see href="https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Builder.html#method.http2_max_frame_size">hyper: http2_max_frame_size</see>
         /// </remarks>
         public uint? Http2MaxFrameSize { get => _settings.Http2MaxFrameSize; set => _settings.Http2MaxFrameSize = value; }
+        
+        /// <summary>
+        /// Gets or sets timeout for TCP connection establishment
+        /// Pass <value>null</value> to never timeout.
+        /// Default is never timeout.
+        /// </summary>
+        /// <remarks>
+        /// <see href="https://docs.rs/hyper-util/latest/hyper_util/client/legacy/connect/struct.HttpConnector.html#method.set_connect_timeout">hyper: set_connect_timeout</see>
+        /// </remarks>
+        public TimeSpan? ConnectTimeout { get => _settings.ConnectTimeout; set => _settings.ConnectTimeout = value; }
 
         /// <summary>
         /// Gets or sets an interval for HTTP2 Ping frames should be sent to keep a connection alive.
@@ -204,6 +214,7 @@ namespace Cysharp.Net.Http
         public uint? Http2InitialConnectionWindowSize { get; set; }
         public bool? Http2AdaptiveWindow { get; set; }
         public uint? Http2MaxFrameSize { get; set; }
+        public TimeSpan? ConnectTimeout { get; set; }
         public TimeSpan? Http2KeepAliveInterval { get; set; }
         public TimeSpan? Http2KeepAliveTimeout { get; set; }
         public bool? Http2KeepAliveWhileIdle { get; set; }
@@ -227,6 +238,7 @@ namespace Cysharp.Net.Http
                 Http2InitialConnectionWindowSize = this.Http2InitialConnectionWindowSize,
                 Http2AdaptiveWindow = this.Http2AdaptiveWindow,
                 Http2MaxFrameSize = this.Http2MaxFrameSize,
+                ConnectTimeout = this.ConnectTimeout,
                 Http2KeepAliveInterval = this.Http2KeepAliveInterval,
                 Http2KeepAliveTimeout = this.Http2KeepAliveTimeout,
                 Http2KeepAliveWhileIdle = this.Http2KeepAliveWhileIdle,


### PR DESCRIPTION
Currently, the time before timing out when starting a TCP connection depends on the socket connection timeout period on the OS side (probably `net.inet.tcp.keepinit`).
For this reason, we have confirmed cases where the timeout takes 75 seconds on iOS/macOS.

This pull request adds a new `connect_timeout` option and sets it as the timeout when connecting to TCP in hyper.