### PR TITLE
Add backpressure control and allow asynchronous flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Once the handler sends a request, these settings become immutable and cannot be 
 |Http2MaxSendBufferSize|Gets or sets the maximum write buffer size for each HTTP/2 stream. Default is currently 1MB, but may change.|
 |Http2InitialMaxSendStreams|Gets or sets the initial maximum of locally initiated (send) streams. This value will be overwritten by the value included in the initial SETTINGS frame received from the peer as part of a connection preface.|
 |UnixDomainSocketPath|Gets or sets the path to a Unix Domain Socket to be used as HTTP communication channel instead of the default TCP.|
+|ResponsePipeOptions|Gets or sets the options for the pipe used to receive the response body.|
 
 Most of them expose [hyper client settings](https://docs.rs/hyper-util/latest/hyper_util/client/legacy/struct.Builder.html), so please check those as well.
 

--- a/native/yaha_native/src/context.rs
+++ b/native/yaha_native/src/context.rs
@@ -33,7 +33,7 @@ use crate::{primitives::{CompletionReason, YahaHttpVersion}};
 
 type OnStatusCodeAndHeadersReceive =
     extern "C" fn(req_seq: i32, state: NonZeroIsize, status_code: i32, version: YahaHttpVersion);
-type OnReceive = extern "C" fn(req_seq: i32, state: NonZeroIsize, length: usize, buf: *const u8);
+type OnReceive = extern "C" fn(req_seq: i32, state: NonZeroIsize, length: usize, buf: *const u8, task_handle: usize);
 type OnComplete = extern "C" fn(req_seq: i32, state: NonZeroIsize, reason: CompletionReason, h2_error_code: u32);
 type OnServerCertificateVerificationHandler = extern "C" fn(callback_state: NonZeroIsize, server_name: *const u8, server_name_len: usize, certificate_der: *const u8, certificate_der_len: usize, now: u64) -> bool;
 

--- a/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
+++ b/src/YetAnotherHttpHandler/NativeHttpHandlerCore.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
@@ -33,7 +33,7 @@ namespace Cysharp.Net.Http
         public delegate void yaha_init_context_on_status_code_and_headers_receive_delegate(int req_seq, nint state, int status_code, YahaHttpVersion version);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void yaha_init_context_on_receive_delegate(int req_seq, nint state, nuint length, byte* buf);
+        public delegate void yaha_init_context_on_receive_delegate(int req_seq, nint state, nuint length, byte* buf, nuint task_handle);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void yaha_init_context_on_complete_delegate(int req_seq, nint state, CompletionReason reason, uint h2_error_code);
@@ -171,6 +171,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_request_destroy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool yaha_request_destroy(YahaNativeContext* ctx, YahaNativeRequestContext* req_ctx);
+
+        [DllImport(__DllName, EntryPoint = "yaha_complete_task", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_complete_task(nuint task_handle);
 
 
     }

--- a/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.Uwp.g.cs
@@ -173,7 +173,7 @@ namespace Cysharp.Net.Http
         public static extern bool yaha_request_destroy(YahaNativeContext* ctx, YahaNativeRequestContext* req_ctx);
 
         [DllImport(__DllName, EntryPoint = "yaha_complete_task", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern void yaha_complete_task(nuint task_handle);
+        public static extern void yaha_complete_task(nuint task_handle, StringBuffer* error);
 
 
     }

--- a/src/YetAnotherHttpHandler/NativeMethods.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.g.cs
@@ -178,7 +178,7 @@ namespace Cysharp.Net.Http
         public static extern bool yaha_request_destroy(YahaNativeContext* ctx, YahaNativeRequestContext* req_ctx);
 
         [DllImport(__DllName, EntryPoint = "yaha_complete_task", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern void yaha_complete_task(nuint task_handle);
+        public static extern void yaha_complete_task(nuint task_handle, StringBuffer* error);
 
 
     }

--- a/src/YetAnotherHttpHandler/NativeMethods.g.cs
+++ b/src/YetAnotherHttpHandler/NativeMethods.g.cs
@@ -38,7 +38,7 @@ namespace Cysharp.Net.Http
         public delegate void yaha_init_context_on_status_code_and_headers_receive_delegate(int req_seq, nint state, int status_code, YahaHttpVersion version);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void yaha_init_context_on_receive_delegate(int req_seq, nint state, nuint length, byte* buf);
+        public delegate void yaha_init_context_on_receive_delegate(int req_seq, nint state, nuint length, byte* buf, nuint task_handle);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void yaha_init_context_on_complete_delegate(int req_seq, nint state, CompletionReason reason, uint h2_error_code);
@@ -176,6 +176,9 @@ namespace Cysharp.Net.Http
         [DllImport(__DllName, EntryPoint = "yaha_request_destroy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool yaha_request_destroy(YahaNativeContext* ctx, YahaNativeRequestContext* req_ctx);
+
+        [DllImport(__DllName, EntryPoint = "yaha_complete_task", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void yaha_complete_task(nuint task_handle);
 
 
     }

--- a/src/YetAnotherHttpHandler/RequestContext.cs
+++ b/src/YetAnotherHttpHandler/RequestContext.cs
@@ -33,11 +33,11 @@ namespace Cysharp.Net.Http
         public PipeWriter Writer => _pipe.Writer;
         public IntPtr Handle => GCHandle.ToIntPtr(_handle);
 
-        internal RequestContext(YahaContextSafeHandle ctx, YahaRequestContextSafeHandle requestContext, HttpRequestMessage requestMessage, int requestSequence, CancellationToken cancellationToken)
+        internal RequestContext(YahaContextSafeHandle ctx, YahaRequestContextSafeHandle requestContext, HttpRequestMessage requestMessage, int requestSequence, PipeOptions? responsePipeOptions,  CancellationToken cancellationToken)
         {
             _ctxHandle = ctx;
             _requestContextHandle = requestContext;
-            _response = new ResponseContext(requestMessage, this, cancellationToken);
+            _response = new ResponseContext(requestMessage, this, responsePipeOptions, cancellationToken);
             _readRequestTask = default;
             _requestSequence = requestSequence;
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/YetAnotherHttpHandler/ResponseContext.cs
+++ b/src/YetAnotherHttpHandler/ResponseContext.cs
@@ -20,6 +20,7 @@ namespace Cysharp.Net.Http
         private readonly CancellationTokenRegistration _tokenRegistration;
         private readonly object _writeLock = new object();
         private bool _completed = false;
+        private Task<FlushResult>? _latestFlushTask;
 
         internal ResponseContext(HttpRequestMessage requestMessage, RequestContext requestContext, PipeOptions? pipeOptions, CancellationToken cancellationToken)
         {
@@ -43,23 +44,28 @@ namespace Cysharp.Net.Http
 #endif
         }
 
-        public void Write(ReadOnlySpan<byte> data)
+        public ValueTask<FlushResult> WriteAsync(ReadOnlySpan<byte> data)
         {
-            // NOTE: Currently, this method is called from the rust-side thread (tokio-worker-thread),
-            //        so care must be taken because throwing a managed exception will cause a crash.
             lock (_writeLock)
             {
-                if (_completed) return;
+                if (_completed) return default;
+
+                WaitForLatestFlush();
 
                 var buffer = _pipe.Writer.GetSpan(data.Length);
                 data.CopyTo(buffer);
                 _pipe.Writer.Advance(data.Length);
-            }
-        }
 
-        public ValueTask<FlushResult> FlushAsync()
-        {
-            return _pipe.Writer.FlushAsync(default);
+                var flush = _pipe.Writer.FlushAsync(_cancellationToken);
+                if (flush.IsCompleted)
+                {
+                    _latestFlushTask = null;
+                    return flush;
+                }
+
+                _latestFlushTask = flush.AsTask();
+                return new ValueTask<FlushResult>(_latestFlushTask);
+            }
         }
 
         public void SetHeader(ReadOnlySpan<byte> nameBytes, ReadOnlySpan<byte> valueBytes)
@@ -106,6 +112,7 @@ namespace Cysharp.Net.Http
             if (YahaEventSource.Log.IsEnabled()) YahaEventSource.Log.Trace($"[ReqSeq:{_requestContext.RequestSequence}] Response completed. (_completed={_completed})");
             lock (_writeLock)
             {
+                WaitForLatestFlush();
                 _pipe.Writer.Complete();
                 _completed = true;
             }
@@ -140,6 +147,7 @@ namespace Cysharp.Net.Http
                 }
 #endif
                 _responseTask.TrySetException(ex);
+                WaitForLatestFlush();
                 _pipe.Writer.Complete(ex);
                 _completed = true;
             }
@@ -153,6 +161,7 @@ namespace Cysharp.Net.Http
             {
                 _requestContext.TryAbort();
                 _responseTask.TrySetCanceled(_cancellationToken);
+                WaitForLatestFlush();
                 _pipe.Writer.Complete(new OperationCanceledException(_cancellationToken));
                 _completed = true;
             }
@@ -175,6 +184,23 @@ namespace Cysharp.Net.Http
             catch (Exception e)
             {
                 throw new HttpRequestException(e.Message, e);
+            }
+        }
+
+        private void WaitForLatestFlush()
+        {
+            // PipeWriter is not thread-safe, so we need to wait for the latest flush task to complete before writing to the pipe.
+
+            if (_latestFlushTask is { IsCompleted: false } latestFlushTask)
+            {
+                try
+                {
+                    latestFlushTask.Wait();
+                }
+                catch (Exception)
+                {
+                    // It is safe to ignore an exception thrown by the latest flush task because it will be caught by NativeHttpHandlerCore.OnReceive().
+                }
             }
         }
 

--- a/src/YetAnotherHttpHandler/ResponseContext.cs
+++ b/src/YetAnotherHttpHandler/ResponseContext.cs
@@ -13,7 +13,7 @@ namespace Cysharp.Net.Http
     internal class ResponseContext
     {
         private readonly RequestContext _requestContext;
-        private readonly Pipe _pipe = new Pipe(System.IO.Pipelines.PipeOptions.Default);
+        private readonly Pipe _pipe;
         private readonly TaskCompletionSource<HttpResponseMessage> _responseTask;
         private readonly HttpResponseMessage _message;
         private readonly CancellationToken _cancellationToken;
@@ -21,8 +21,9 @@ namespace Cysharp.Net.Http
         private readonly object _writeLock = new object();
         private bool _completed = false;
 
-        internal ResponseContext(HttpRequestMessage requestMessage, RequestContext requestContext, CancellationToken cancellationToken)
+        internal ResponseContext(HttpRequestMessage requestMessage, RequestContext requestContext, PipeOptions? pipeOptions, CancellationToken cancellationToken)
         {
+            _pipe = new Pipe(pipeOptions ?? PipeOptions.Default);
             _requestContext = requestContext;
             _responseTask = new TaskCompletionSource<HttpResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
             _cancellationToken = cancellationToken;

--- a/src/YetAnotherHttpHandler/ResponseContext.cs
+++ b/src/YetAnotherHttpHandler/ResponseContext.cs
@@ -53,12 +53,12 @@ namespace Cysharp.Net.Http
                 var buffer = _pipe.Writer.GetSpan(data.Length);
                 data.CopyTo(buffer);
                 _pipe.Writer.Advance(data.Length);
-                var t = _pipe.Writer.FlushAsync();
-                if (!t.IsCompleted)
-                {
-                    t.AsTask().GetAwaiter().GetResult();
-                }
             }
+        }
+
+        public ValueTask<FlushResult> FlushAsync()
+        {
+            return _pipe.Writer.FlushAsync(default);
         }
 
         public void SetHeader(ReadOnlySpan<byte> nameBytes, ReadOnlySpan<byte> valueBytes)

--- a/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
+++ b/src/YetAnotherHttpHandler/YetAnotherHttpHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO.Pipelines;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -174,6 +175,11 @@ namespace Cysharp.Net.Http
         /// </summary>
         public string? UnixDomainSocketPath { get => _settings.UnixDomainSocketPath; set => _settings.UnixDomainSocketPath = value; }
 
+        /// <summary>
+        /// Gets or sets the options for the pipe used to receive the response body.
+        /// </summary>
+        public PipeOptions? ResponsePipeOptions { get => _settings.ResponsePipeOptions; set => _settings.ResponsePipeOptions = value; }
+
         private NativeHttpHandlerCore SetupHandler()
         {
             var settings = _settings.Clone();
@@ -242,6 +248,7 @@ namespace Cysharp.Net.Http
         public ulong? Http2MaxSendBufferSize { get; set; }
         public ulong? Http2InitialMaxSendStreams { get; set; }
         public string? UnixDomainSocketPath { get; set; }
+        public PipeOptions? ResponsePipeOptions { get; set; }
 
         public NativeClientSettings Clone()
         {
@@ -268,6 +275,7 @@ namespace Cysharp.Net.Http
                 Http2MaxSendBufferSize = this.Http2MaxSendBufferSize,
                 Http2InitialMaxSendStreams = this.Http2InitialMaxSendStreams,
                 UnixDomainSocketPath = this.UnixDomainSocketPath,
+                ResponsePipeOptions = this.ResponsePipeOptions,
             };
         }
     }

--- a/test/YetAnotherHttpHandler.Test/BackPressureTest.cs
+++ b/test/YetAnotherHttpHandler.Test/BackPressureTest.cs
@@ -1,0 +1,40 @@
+using Cysharp.Net.Http;
+using Xunit.Abstractions;
+
+namespace _YetAnotherHttpHandler.Test;
+
+public class BackPressureTest(ITestOutputHelper testOutputHelper) : UseTestServerTestBase(testOutputHelper)
+{
+    private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
+
+    [Theory]
+    [InlineData(4186)] // pass
+    [InlineData(65535)] // pass
+    [InlineData(65536)] // fail
+    [InlineData(131972)] // fail
+    public async Task FlushTest(int size)
+    {
+        using var httpHandler = new YetAnotherHttpHandler();
+        using var client = new HttpClient(httpHandler);
+        await using var server = await LaunchServerAsync<TestServerForHttp1AndHttp2>(TestWebAppServerListenMode.InsecureHttp1Only);
+
+        var numRequests = Environment.ProcessorCount + 1; // more than the number of tokio worker threads
+
+        _testOutputHelper.WriteLine($"NumRequests: {numRequests}");
+
+        var pendingStreams = new List<Stream>();
+
+        for (var i = 0; i < numRequests; i++)
+        {
+            _testOutputHelper.WriteLine($"Request #{i}");
+
+            using var timeout = new CancellationTokenSource();
+            timeout.CancelAfter(TimeSpan.FromSeconds(10));
+            var stream = await client.GetStreamAsync($"{server.BaseUri}/random?size={size}", timeout.Token);
+
+            pendingStreams.Add(stream);
+        }
+
+        foreach (var stream in pendingStreams) await stream.DisposeAsync();
+    }
+}

--- a/test/YetAnotherHttpHandler.Test/TestServerForHttp1AndHttp2.cs
+++ b/test/YetAnotherHttpHandler.Test/TestServerForHttp1AndHttp2.cs
@@ -177,6 +177,12 @@ class TestServerForHttp1AndHttp2 : ITestServerBuilder
             }
             return Results.Empty;
         });
+        app.MapGet("/random", (int size) =>
+        {
+            var buffer = new byte[size];
+            Random.Shared.NextBytes(buffer);
+            return Results.Bytes(buffer, "application/octet-stream");
+        });
 
         // HTTP/2
         app.MapGet("/error-reset", (HttpContext httpContext) =>


### PR DESCRIPTION
## Problem

I've wanted to control the amount of backpressure when reading a response using a stream. Specifically, the value of `pauseWriterThreshold` in `PipeOptions.Default` of the Pipe that `Cysharp.Net.Http.ResponseContext` has is 64KiB. I would like to change this value.

https://github.com/dotnet/runtime/blob/b9691b06b96541e8e94cd79f17d6447b8d03ec20/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs#L47-L48

However, I have noticed that the progress of the other requests may be blocked when backpressure is occurring. Upon investigation, I found that this is caused by waiting for `PipeWriter.FlushAsync()` synchronously, which blocks `FlushAsync()` while backpressure is occurring, blocking the worker thread on the native side.

https://github.com/Cysharp/YetAnotherHttpHandler/blob/1f499bc99d05372fcdd015d7422d5b189b2d2592/src/YetAnotherHttpHandler/ResponseContext.cs#L56-L60

Here is the example.
If I call multiple requests concurrently with larger response body than `pauseWriterThreshold` (64KiB) and intentionally cause backpressure by not reading the stream, the subsequent request stops progressing and times out in the middle. This can be problematic when there are large numbers of concurrent requests.

```
NumRequests: 11
Request #0
Request #1
System.Threading.Tasks.TaskCanceledException: The operation was canceled.
```

```csharp
using Cysharp.Net.Http;
using Xunit.Abstractions;

namespace _YetAnotherHttpHandler.Test;

public class BackPressureTest
{
    private readonly ITestOutputHelper _testOutputHelper;

    public BackPressureTest(ITestOutputHelper testOutputHelper)
    {
        _testOutputHelper = testOutputHelper;
    }

    [Theory]
    [InlineData(4186)] // pass
    [InlineData(65535)] // pass
    [InlineData(65536)] // fail
    [InlineData(131972)] // fail
    public async Task FlushTest(int size)
    {
        using var httpHandler = new YetAnotherHttpHandler();
        using var client = new HttpClient(httpHandler);

        var numRequests = Environment.ProcessorCount + 1; // more than the number of tokio worker threads

        _testOutputHelper.WriteLine($"NumRequests: {numRequests}");

        var pendingStreams = new List<Stream>();

        for (var i = 0; i < numRequests; i++)
        {
            _testOutputHelper.WriteLine($"Request #{i}");

            using var timeout = new CancellationTokenSource();
            timeout.CancelAfter(TimeSpan.FromSeconds(10));
            var stream = await client.GetStreamAsync($"https://httpbin.org/bytes/{size}", timeout.Token);

            pendingStreams.Add(stream);
        }

        foreach (var stream in pendingStreams) await stream.DisposeAsync();
    }
}
```


## Solution

I have found that if I make a change that allows `PipeWriter.FlushAsync()` to be awaited asynchronously, it passes the same test.

This PR adds a `ResponsePipeOptions` property to `YetAnotherHttpHandler` and allows it to wait for `PipeWriter.FlushAsync()` asynchronously.